### PR TITLE
fix multipart serializer

### DIFF
--- a/src/Griffin.Framework/Griffin.Core.Tests/Griffin.Core.Tests.csproj
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Griffin.Core.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Net\Protocols\Http\Messages\HeaderParserTests.cs" />
     <Compile Include="Net\Protocols\Http\Messages\HttpCookieParserTests.cs" />
     <Compile Include="Net\Protocols\Http\Messages\HttpMessageDecoderTests.cs" />
+    <Compile Include="Net\Protocols\Http\BodyDecoders\MultipartSerializerTests.cs" />
     <Compile Include="Net\Protocols\Http\BodyDecoders\UrlDecoderTests.cs" />
     <Compile Include="Net\Protocols\Http\HttpEncoderTests.cs" />
     <Compile Include="Net\Protocols\Http\HttpMessageDecoderTests.cs" />

--- a/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/BodyDecoders/MultipartSerializerTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/BodyDecoders/MultipartSerializerTests.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+using System.Text;
+using Griffin.Net.Protocols.Http.Serializers;
+using Xunit;
+
+namespace Griffin.Core.Tests.Net.Protocols.Http.BodyDecoders
+{
+    public class MultipartSerializerTests
+    {
+        [Fact]
+        public void DecodeFile()
+        {
+            var contentType = "multipart/form-data; boundary=AaB03x";
+            var message = "--AaB03x\r\nContent-Disposition: form-data; name=\"hello\"\r\n\r\nworld\r\n--AaB03x\r\nContent-Disposition: form-data; name=\"file\"; filename=\"file.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--AaB03x--";
+            var bytes = Encoding.ASCII.GetBytes(message);
+            var body = new MemoryStream(bytes);
+
+            var decoder = new MultipartSerializer();
+            var result = decoder.Deserialize(contentType, body);
+
+            Assert.Equal("world", ((FormAndFilesResult)result).Form["hello"]);
+            Assert.Equal("file", ((FormAndFilesResult)result).Files["file"].Name);
+            Assert.Equal("file.txt", ((FormAndFilesResult)result).Files["file"].OriginalFileName);
+            Assert.Equal("text/plain", ((FormAndFilesResult)result).Files["file"].ContentType);
+            Assert.Equal("hello world", File.ReadAllText(((FormAndFilesResult)result).Files["file"].TempFileName));
+        }
+    }
+}

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/Serializers/MultipartSerializer.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/Serializers/MultipartSerializer.cs
@@ -57,7 +57,10 @@ namespace Griffin.Net.Protocols.Http.Serializers
         /// <exception cref="SerializationException">Deserialization failed</exception>
         public object Deserialize(string contentType, Stream source)
         {
-            if (!contentType.EndsWith(MimeType))
+            if (contentType == null) throw new ArgumentNullException("contentType");
+            if (source == null) throw new ArgumentNullException("source");
+
+            if (!contentType.StartsWith(MimeType, StringComparison.OrdinalIgnoreCase))
                 return null;
 
             var result = new FormAndFilesResult()
@@ -67,7 +70,7 @@ namespace Griffin.Net.Protocols.Http.Serializers
             };
             var contentTypeHeader = new HttpHeaderValue(contentType);
             var encodingStr = contentTypeHeader.Parameters["charset"];
-            var encoding = Encoding.GetEncoding(encodingStr);
+            var encoding = encodingStr != null ? Encoding.GetEncoding(encodingStr) : Encoding.UTF8;
 
             //multipart/form-data, boundary=AaB03x
             var boundry = contentTypeHeader.Parameters.Get("boundary");


### PR DESCRIPTION
The MultipartSerializer was broken because it didn't correctly checked the content-type (which now follows the same logic as the UrlFormattedMessageSerializer) and also required a charset which is often not provided (see http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4)
