### PR TITLE
fix MicroMessageEncoder bug

### DIFF
--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/MicroMsg/MicroMessageEncoder.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/MicroMsg/MicroMessageEncoder.cs
@@ -205,7 +205,7 @@ namespace Griffin.Net.Protocols.MicroMsg
 
             // the header length field is not included in _headerSize as it's a header prefix.
             // hence the +2
-            return _headerSize + 2;
+            return _headerSize;
         }
     }
 }

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/MicroMsg/MicroMessageEncoder.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/MicroMsg/MicroMessageEncoder.cs
@@ -202,9 +202,6 @@ namespace Griffin.Net.Protocols.MicroMsg
             BitConverter2.GetBytes((int)_bodyStream.Length, sliceBuffer, sliceOffset + 2 + 1);
             BitConverter2.GetBytes((byte)contentType.Length, sliceBuffer, sliceOffset + 2 + 1 + 4);
             Encoding.UTF8.GetBytes(contentType, 0, contentType.Length, sliceBuffer, sliceOffset + 2 + 1 + 4 + 1);
-
-            // the header length field is not included in _headerSize as it's a header prefix.
-            // hence the +2
             return _headerSize;
         }
     }


### PR DESCRIPTION
FixedHeaderLength  is defined by   sizeof(ushort) + sizeof (byte) + sizeof (int) + sizeof (byte);
the header length field is included in _headerSize,so can't +2