### PR TITLE
fix http response parsing

### DIFF
--- a/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpEncoderTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpEncoderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using System.Text;
 using FluentAssertions;
 using Griffin.Net.Protocols.Http;
@@ -61,7 +62,7 @@ namespace Griffin.Core.Tests.Net.Protocols.Http
         [Fact]
         public void response_with_body()
         {
-            var frame = new HttpResponseBase(404, "Failed to find it dude", "HTTP/1.1");
+            var frame = new HttpResponseBase(HttpStatusCode.NotFound, "Failed to find it dude", "HTTP/1.1");
             frame.AddHeader("X-Requested-With", "XHttpRequest");
             frame.ContentType = "text/plain";
             frame.Body = new MemoryStream(Encoding.ASCII.GetBytes("hello queue a"));
@@ -80,7 +81,7 @@ namespace Griffin.Core.Tests.Net.Protocols.Http
         [Fact]
         public void response_with_body_encoding()
         {
-            var frame = new HttpResponseBase(404, "Failed to find it dude", "HTTP/1.1");
+            var frame = new HttpResponseBase(HttpStatusCode.NotFound, "Failed to find it dude", "HTTP/1.1");
             frame.AddHeader("X-Requested-With", "XHttpRequest");
             frame.ContentType = "text/plain";
             frame.ContentCharset = Encoding.UTF8;

--- a/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpMessageDecoderTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpMessageDecoderTests.cs
@@ -242,5 +242,71 @@ hello queue a");
             sw.ReadToEnd().Should().Be("hello queue a");
         }
 
+        [Fact]
+        public void basic_response()
+        {
+            IHttpResponse actual = null;
+            var buffer = new SocketBufferFake();
+            buffer.Buffer = Encoding.ASCII.GetBytes("HTTP/1.1 404 Failed to find it dude\r\nServer: griffinframework.net\r\n\r\n");
+            buffer.BytesTransferred = buffer.Buffer.Length;
+
+            var decoder = new HttpMessageDecoder();
+            decoder.MessageReceived = o => actual = (IHttpResponse)o;
+            decoder.ProcessReadBytes(buffer);
+
+            actual.Should().NotBeNull();
+            actual.StatusCode.Should().Be(404);
+            actual.HttpVersion.Should().Be("HTTP/1.1");
+            actual.ReasonPhrase.Should().Be("Failed to find it dude");
+            actual.Headers["Server"].Should().Be("griffinframework.net");
+        }
+
+        [Fact]
+        public void response_with_body()
+        {
+            IHttpResponse actual = null;
+            var buffer = new SocketBufferFake();
+            buffer.Buffer = Encoding.ASCII.GetBytes("HTTP/1.1 404 Failed to find it dude\r\nServer: griffinframework.net\r\nContent-Type: text/plain\r\nX-Requested-With: XHttpRequest\r\nContent-Length: 13\r\n\r\nhello queue a\r\n\r\n");
+            buffer.BytesTransferred = buffer.Buffer.Length;
+
+            var decoder = new HttpMessageDecoder();
+            decoder.MessageReceived = o => actual = (IHttpResponse)o;
+            decoder.ProcessReadBytes(buffer);
+
+            actual.Should().NotBeNull();
+            actual.StatusCode.Should().Be(404);
+            actual.HttpVersion.Should().Be("HTTP/1.1");
+            actual.ReasonPhrase.Should().Be("Failed to find it dude");
+            actual.Headers["Server"].Should().Be("griffinframework.net");
+            actual.Headers["X-Requested-With"].Should().Be("XHttpRequest");
+            actual.ContentType.Should().Be("text/plain");
+            actual.ContentLength.Should().Be(13);
+            new StreamReader(actual.Body).ReadToEnd().Should().Be("hello queue a");
+        }
+
+        [Fact]
+        public void response_with_body_encoding()
+        {
+            IHttpResponse actual = null;
+            var buffer = new SocketBufferFake();
+            buffer.Buffer = Encoding.ASCII.GetBytes("HTTP/1.1 404 Failed to find it dude\r\nServer: griffinframework.net\r\nContent-Type: text/plain;charset=utf-8\r\nX-Requested-With: XHttpRequest\r\nContent-Length: 13\r\n\r\nhello queue a\r\n\r\n");
+            buffer.BytesTransferred = buffer.Buffer.Length;
+
+            var decoder = new HttpMessageDecoder();
+            decoder.MessageReceived = o => actual = (IHttpResponse)o;
+            decoder.ProcessReadBytes(buffer);
+
+            actual.Should().NotBeNull();
+            actual.StatusCode.Should().Be(404);
+            actual.HttpVersion.Should().Be("HTTP/1.1");
+            actual.ReasonPhrase.Should().Be("Failed to find it dude");
+            actual.Headers["Server"].Should().Be("griffinframework.net");
+            actual.Headers["X-Requested-With"].Should().Be("XHttpRequest");
+            actual.ContentType.Should().Be("text/plain");
+            actual.ContentLength.Should().Be(13);
+            actual.ContentCharset.Should().Be(Encoding.UTF8);
+            new StreamReader(actual.Body, actual.ContentCharset).ReadToEnd().Should().Be("hello queue a");
+        }
+
     }
 }

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpResponse.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpResponse.cs
@@ -13,7 +13,7 @@ namespace Griffin.Net.Protocols.Http
         /// <param name="statusCode">The status code.</param>
         /// <param name="reasonPhrase">The reason phrase.</param>
         /// <param name="httpVersion">The HTTP version.</param>
-        public HttpResponse(int statusCode, string reasonPhrase, string httpVersion) : base(statusCode, reasonPhrase, httpVersion)
+        internal HttpResponse(int statusCode, string reasonPhrase, string httpVersion) : base(statusCode, reasonPhrase, httpVersion)
         {
             Cookies = new HttpCookieCollection<IResponseCookie>();
         }

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpResponseBase.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpResponseBase.cs
@@ -22,15 +22,11 @@ namespace Griffin.Net.Protocols.Http
         /// <param name="reasonPhrase">The reason phrase.</param>
         /// <param name="httpVersion">The HTTP version.</param>
         /// <exception cref="System.ArgumentNullException">reasonPhrase</exception>
-        public HttpResponseBase(int statusCode, string reasonPhrase, string httpVersion) : base(httpVersion)
+        internal HttpResponseBase(int statusCode, string reasonPhrase, string httpVersion) : base(httpVersion)
         {
             if (reasonPhrase == null) throw new ArgumentNullException("reasonPhrase");
-
             StatusCode = statusCode;
             ReasonPhrase = reasonPhrase;
-            Headers["Server"] = "griffinframework.net";
-            Headers["Date"] = DateTime.UtcNow.ToString("R");
-            Headers["Content-Type"] = "text/html";
         }
 
         /// <summary>

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/Messages/HeaderParser.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/Messages/HeaderParser.cs
@@ -58,7 +58,7 @@ namespace Griffin.Net.Protocols.Http.Messages
                 return tmp;
             }
 
-            if (offset - buffer.BaseOffset  >= buffer.BytesTransferred)
+            if (offset - buffer.BaseOffset >= buffer.BytesTransferred)
                 return -1;
 
             return buffer.Buffer[offset++];
@@ -74,16 +74,8 @@ namespace Griffin.Net.Protocols.Http.Messages
                 return;
             if (ch == '\n')
             {
-                var line = _headerName.ToString().Split(' ');
-                if (line.Length != 3)
-                    throw new BadRequestException(string.Format("First line is not a valid REQUEST/RESPONSE line: '{0}'.", _headerName));
-
-                if (line[2].ToLower().StartsWith("http"))
-                    RequestLineParsed(line[0], line[1], line[2]);
-                else
-                {
-                    throw new NotSupportedException("Not supporting response parsing yet.");
-                }
+                var line = _headerName.ToString().Split(new char[] { ' ' }, 3);
+                RequestLineParsed(line[0], line[1], line[2]);
 
                 _headerName.Clear();
                 _parserMethod = Name_StripWhiteSpacesBefore;


### PR DESCRIPTION
The first issue was that the first headerline can have more than three parts after splitting with `' '` (space char). e.g. `HTTP/1.1 404 Not Found`.

The second issue was that the `ResponseBase` class automatically sets default headers for `Server`, `Date` and `Content-Type` and since the `HeaderCollection` does not allow multiple headers with the same name I had to make the `ResponseBase` constructor with the `int statusCode` argument internal and remove the header initialization. Which would be a breaking change...
