### PR TITLE
logger format exception tests should not be locale specific

### DIFF
--- a/src/Griffin.Framework/Griffin.Core.Tests/Logging/Loggers/BaseLoggerTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Logging/Loggers/BaseLoggerTests.cs
@@ -212,7 +212,7 @@ namespace Griffin.Core.Tests.Logging.Loggers
             var sut = new BaseLoggerWrapper(GetType());
             var actual = sut.FormatException(exception);
 
-            actual.Should().Be("    System.NotImplementedException: The method or operation is not implemented.\r\n");
+            actual.Should().StartWith("    System.NotImplementedException");
         }
 
         [Fact]
@@ -223,7 +223,8 @@ namespace Griffin.Core.Tests.Logging.Loggers
             var sut = new BaseLoggerWrapper(GetType());
             var actual = sut.FormatException(exception);
 
-            actual.Should().Be("    Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty: Exception of type 'Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty' was thrown.\r\n    [UserId='10']\r\n");
+            actual.Should().StartWith("    Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty");
+            actual.Should().EndWith("[UserId='10']\r\n");
         }
 
         [Fact]
@@ -234,7 +235,8 @@ namespace Griffin.Core.Tests.Logging.Loggers
             var sut = new BaseLoggerWrapper(GetType());
             var actual = sut.FormatException(exception);
 
-            actual.Should().Be("    Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty2: Exception of type 'Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty2' was thrown.\r\n    [UserId='10',FirstName='Arne']\r\n");
+            actual.Should().StartWith("    Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty2");
+            actual.Should().EndWith("[UserId='10',FirstName='Arne']\r\n");
         }
 
         [Fact]
@@ -245,7 +247,8 @@ namespace Griffin.Core.Tests.Logging.Loggers
             var sut = new BaseLoggerWrapper(GetType());
             var actual = sut.FormatException(exception);
 
-            actual.Should().Be("    Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty2: Exception of type 'Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty2' was thrown.\r\n    [UserId='10']\r\n");
+            actual.Should().StartWith("    Griffin.Core.Tests.Logging.Loggers.ExceptionWithProperty2");
+            actual.Should().EndWith("[UserId='10']\r\n");
         }
 
     }


### PR DESCRIPTION
Now the tests only check for none locale specific parts.

(These tests failed every time in my german development environment.)