### PR TITLE
[Website] ignore null or empty second lines in markdown table parser

### DIFF
--- a/Griffin.FrameworkWeb/Infrastructure/Parser.cs
+++ b/Griffin.FrameworkWeb/Infrastructure/Parser.cs
@@ -88,7 +88,7 @@ namespace GriffinFrameworkWeb.Infrastructure
 
                 var firstLine = line;
                 line = reader.ReadLine();
-                if (line == null)
+                if (string.IsNullOrEmpty(line))
                 {
                     sb.AppendLine(firstLine);
                     continue;


### PR DESCRIPTION
This fixes table generation if the first line contains a ` | ` string followed by an empty line.

e.g. here http://griffinframework.net/doc/Data/mapper/api

Wrong:
![image](https://cloud.githubusercontent.com/assets/4009570/5607704/afca9326-9465-11e4-912a-2e6ae16e56fe.png)

Correct:
![image](https://cloud.githubusercontent.com/assets/4009570/5607713/50731b68-9466-11e4-81f8-a1d5564fa29c.png)
