### PR TITLE
[Website] fixed some code highlighting and broken links

### DIFF
--- a/Griffin.FrameworkWeb/DocPages/Data/mapper/api.md
+++ b/Griffin.FrameworkWeb/DocPages/Data/mapper/api.md
@@ -72,13 +72,13 @@ Deletes can be done both on the connection and the unit of work, just as Inserts
 
 If you've already fetched the entity you can use it in the delete command:
 
-```charp
+```csharp
 _unitOfWork.Delete(user);
 ```
 
 You can also specify just the key in the entity:
 
-```charp
+```csharp
 _unitOfWork.Delete(new User { Id = userId });
 ```
 
@@ -86,7 +86,7 @@ _unitOfWork.Delete(new User { Id = userId });
 
 You can use an anonymous object (names must be same as the property names, and the value must be of the same type as defined in the properties):
 
-```charp
+```csharp
 _unitOfWork.Delete<User>(new { Id = userId });
 ```
 
@@ -94,7 +94,7 @@ _unitOfWork.Delete<User>(new { Id = userId });
 
 You can specify multiple columns:
 
-```charp
+```csharp
 _unitOfWork.Delete<User>(new { FirstName = firstName, LastName = lastName });
 ```
 
@@ -105,13 +105,13 @@ _unitOfWork.Delete<User>(new { FirstName = firstName, LastName = lastName });
 
 Short queries allows you to only specify the WHERE statement and to include the parameters directly.
 
-```charp
+```csharp
 _unitOfWork.Delete<User>("expires < @date", new { id = minDate ));
 ```
 
 You can use a value array:
 
-```charp
+```csharp
 _unitOfWork.Delete<User>("expires < @1 AND state = @2", minDate, UserState.ActivationRequired);
 ```
 
@@ -119,13 +119,13 @@ _unitOfWork.Delete<User>("expires < @1 AND state = @2", minDate, UserState.Activ
 
 You can also write complete queries:
 
-```charp
+```csharp
 _unitOfWork.Delete<User>("DELETE FROM Users WHERE expires < @date", new { id = minDate ));
 ```
 
 You can use a value array:
 
-```charp
+```csharp
 _unitOfWork.Delete<User>("DELETE FROM Users WHERE expires < @1 AND state = @2", minDate, UserState.ActivationRequired);
 ```
 

--- a/Griffin.FrameworkWeb/DocPages/Data/mapper/api.md
+++ b/Griffin.FrameworkWeb/DocPages/Data/mapper/api.md
@@ -5,13 +5,13 @@ This library have full support for asynchronous operations in the data layer.
 To see them, [go here](async_api).
 
 
-[CRUD](#CRUD) | [First & FirstOrDefault](#FIRST) | [ToEnumerable & ToList](TOENUMERABLE)
+[CRUD](#CRUD) | [First & FirstOrDefault](#FIRST) | [ToEnumerable & ToList](#TOENUMERABLE)
 
-<a name="CRUD"/>
+<a name="CRUD"></a>
 # CRUD operations
 
 CRUD operations are provided both for `IDbConnection`, `IAdoNetUnitOfWork` and `DbCommand`. All CRUD operations
-require that you have defined a `ICrudEntityMapper<T>` for your entity. For more information read the [Mappings](Mappings.md) page.
+require that you have defined a `ICrudEntityMapper<T>` for your entity. For more information read the [Mappings](Mappings) page.
 
 ## INSERT
 
@@ -129,7 +129,7 @@ You can use a value array:
 _unitOfWork.Delete<User>("DELETE FROM Users WHERE expires < @1 AND state = @2", minDate, UserState.ActivationRequired);
 ```
 
-<a name="FIRST" />
+<a name="FIRST"></a>
 #First & FirstOrDefault
 
 Sometimes you want to fetch a single item. These methods are specialized for that. The methods works for `IDbConnection`, `IAdoNetUnitOfWork` and `DbCommand`.
@@ -199,6 +199,7 @@ var user = _unitOfWork.First<Age>("SELECT Age FROM Users WHERE FirstName = @1 AN
 
 Works just like First, and the syntax is the same. The difference is just that `null` is returned if no rows are found.
 
+<a name="TOENUMERABLE"></a>
 #ToList
 
 ToList have the same API as `First()`/`FirstOrDefault()`, but a list is returned instead. 

--- a/Griffin.FrameworkWeb/DocPages/Data/mapper/async_api.md
+++ b/Griffin.FrameworkWeb/DocPages/Data/mapper/async_api.md
@@ -12,13 +12,13 @@ enforced by .NET and not by this library (there are no interfaces for the async 
 Most ADO.NET drivers is however based in the `DbCommand` base class and should therefore work fine.
 
 
-[CRUD](#CRUD) | [First & FirstOrDefault](#FIRST) | [ToEnumerable & ToList](TOENUMERABLE)
+[CRUD](#CRUD) | [First & FirstOrDefault](#FIRST) | [ToEnumerable & ToList](#TOENUMERABLE)
 
-<a name="CRUD"/>
+<a name="CRUD"></a>
 # CRUD operations
 
 CRUD operations are provided both for `IDbConnection`, `IAdoNetUnitOfWork` and `DbCommand`. All CRUD operations
-require that you have defined a `ICrudEntityMapper<T>` for your entity. For more information read the [Mappings](Mappings.md) page.
+require that you have defined a `ICrudEntityMapper<T>` for your entity. For more information read the [Mappings](Mappings) page.
 
 ## INSERT
 
@@ -136,7 +136,7 @@ You can use a value array:
 await _unitOfWork.DeleteAsync<User>("DELETE FROM Users WHERE expires < @1 AND state = @2", minDate, UserState.ActivationRequired);
 ```
 
-<a name="FIRST" />
+<a name="FIRST"></a>
 #First & FirstOrDefault
 
 Sometimes you want to fetch a single item. These methods are specialized for that. The methods works for `IDbConnection`, `IAdoNetUnitOfWork` and `DbCommand`.
@@ -206,6 +206,7 @@ var user = await _unitOfWork.FirstAsync<Age>("SELECT Age FROM Users WHERE FirstN
 
 Works just like First, and the syntax is the same. The difference is just that `null` is returned if no rows are found.
 
+<a name="TOENUMERABLE"></a>
 #ToListAsync
 
 ToList have the same API as `FirstAsync()`/`FirstOrDefaultAsync()`, but a list is returned instead. 

--- a/Griffin.FrameworkWeb/DocPages/Data/mapper/async_api.md
+++ b/Griffin.FrameworkWeb/DocPages/Data/mapper/async_api.md
@@ -79,13 +79,13 @@ Deletes can be done both on the connection and the unit of work, just as Inserts
 
 If you've already fetched the entity you can use it in the delete command:
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync(user);
 ```
 
 You can also specify just the key in the entity:
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync(new User { Id = userId });
 ```
 
@@ -93,7 +93,7 @@ await _unitOfWork.DeleteAsync(new User { Id = userId });
 
 You can use an anonymous object (names must be same as the property names, and the value must be of the same type as defined in the properties):
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync<User>(new { Id = userId });
 ```
 
@@ -101,7 +101,7 @@ await _unitOfWork.DeleteAsync<User>(new { Id = userId });
 
 You can specify multiple columns:
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync<User>(new { FirstName = firstName, LastName = lastName });
 ```
 
@@ -112,13 +112,13 @@ await _unitOfWork.DeleteAsync<User>(new { FirstName = firstName, LastName = last
 
 Short queries allows you to only specify the WHERE statement and to include the parameters directly.
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync<User>("expires < @date", new { id = minDate ));
 ```
 
 You can use a value array:
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync<User>("expires < @1 AND state = @2", minDate, UserState.ActivationRequired);
 ```
 
@@ -126,13 +126,13 @@ await _unitOfWork.DeleteAsync<User>("expires < @1 AND state = @2", minDate, User
 
 You can also write complete queries:
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync<User>("DELETE FROM Users WHERE expires < @date", new { id = minDate ));
 ```
 
 You can use a value array:
 
-```charp
+```csharp
 await _unitOfWork.DeleteAsync<User>("DELETE FROM Users WHERE expires < @1 AND state = @2", minDate, UserState.ActivationRequired);
 ```
 

--- a/Griffin.FrameworkWeb/DocPages/Data/mapper/index.md
+++ b/Griffin.FrameworkWeb/DocPages/Data/mapper/index.md
@@ -8,7 +8,7 @@ understand what went wrong.
 Do note that this is a mapping layer and not a OR/M. You still have to write your
 SQL queries, but with a simpler API. You can for instance write:
 
-```charp
+```csharp
 var users = connection.ToList<User>("firstName LIKE @1 AND lastName LIKE @2", firstName, lastName);
 ```
 

--- a/Griffin.FrameworkWeb/DocPages/Data/mapper/index.md
+++ b/Griffin.FrameworkWeb/DocPages/Data/mapper/index.md
@@ -31,7 +31,7 @@ There is also a repository pattern [sample](repository).
 
 # More info
 
-* [API)(api) / [Async api](async_api)
+* [API](api) / [Async api](async_api)
 * [Mappings](mappings)
 * [Repository](repository)
 

--- a/Griffin.FrameworkWeb/DocPages/cqs/index.md
+++ b/Griffin.FrameworkWeb/DocPages/cqs/index.md
@@ -86,6 +86,7 @@ At client side register CqsClient as ICommandBus, IQueryBus, IEventBus and IRequ
 
 Sample setup:
 
+```csharp
 class ClientDemo
 {
     private CqsClient _client;
@@ -115,8 +116,11 @@ class ClientDemo
         Console.WriteLine("Client: First discount: " + discounts[0].Name);
     }
 }
+```
+
 The server is configured like this:
 
+```csharp
 public class ServerDemo
 {
     private LiteServer _server;
@@ -155,6 +159,8 @@ public class ServerDemo
         _server.Start(IPAddress.Any, 0);
     }
 }
+```
+
 This implementation will also transport all exceptions from the server back to the client automatically. That makes the client/server implementation transparent (if you ignore the network latency) to the caller.
 
 

--- a/Griffin.FrameworkWeb/DocPages/ioc/index.md
+++ b/Griffin.FrameworkWeb/DocPages/ioc/index.md
@@ -18,7 +18,7 @@ way of
 Simply add the `[ContainerService]` attribute to your classes and then register them using the `RegisterServices()` extension method.
 
 
-## example
+## Example
 
 ```csharp
 // Add this attribute.

--- a/Griffin.FrameworkWeb/DocPages/networking/index.md
+++ b/Griffin.FrameworkWeb/DocPages/networking/index.md
@@ -247,7 +247,7 @@ public class MyProtocolEncoder : IMessageEncoder
 
 The decoder have to take into account that messages might be partial or that the incoming stream contains several messages.
 
-```
+```csharp
 public class MyProtocolDecoder : IMessageDecoder
 {
     private readonly byte[] _headerBuf = new byte[4];
@@ -314,7 +314,7 @@ public class MyProtocolDecoder : IMessageDecoder
 
 Here is a sample implementation which a custom protocol (length header + JSON). It can send any type of object over the network (as long as JSON.NET can serialize it).
 
-```
+```csharp
 class Program
 {
     static void Main(string[] args)
@@ -362,7 +362,7 @@ class Program
 
 Here is a sample HTTP server:
 
-```
+```csharp
 class Program2
 {
     static void Main(string[] args)


### PR DESCRIPTION
Code highlighting now always uses `csharp`. Sometimes `charp` was used but it did not work.
Also fixing some broken inks.