### PR TITLE
ignore empty cookie names as defined in rfc 6265

### DIFF
--- a/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/Messages/HttpCookieParserTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/Messages/HttpCookieParserTests.cs
@@ -21,5 +21,14 @@ namespace Griffin.Core.Tests.Net.Protocols.Http.Messages
             Assert.Equal("28603", cookies["km_ni"].Value);
             Assert.Equal("140029553.1355396765.179.62.utmcsr=google|utmccn=(organic)|utmcmd=organic|utmctr=(not%20provided)", cookies["__utmz"].Value);
         }
+
+        [Fact]
+        public void Test_empty_name()
+        {
+            var parser = new HttpCookieParser();
+            var cookies = parser.Parse("=abc");
+
+            Assert.Equal(0, cookies.Count);
+        }
     }
 }

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/Messages/HttpCookieParser.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/Messages/HttpCookieParser.cs
@@ -145,6 +145,7 @@ namespace Griffin.Net.Protocols.Http.Messages
         private void OnCookie(string name, string value)
         {
             if (name == null) throw new ArgumentNullException("name");
+            if (name == "") return; // ignore empty cookie names as defined in rfc 6265 http://tools.ietf.org/html/rfc6265
 
             _cookies.Add(new HttpCookie(name, value));
         }


### PR DESCRIPTION
http://tools.ietf.org/html/rfc6265#section-5.2

    5.  If the name string is empty, ignore the set-cookie-string
        entirely.