### PR TITLE
fix BadRequest response in OnDecodeFailure

### DIFF
--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpListener.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpListener.cs
@@ -77,6 +77,8 @@ namespace Griffin.Net.Protocols.Http
             var pos = error.Message.IndexOfAny(new[] {'\r', '\n'});
             var descr = pos == -1 ? error.Message : error.Message.Substring(0, pos);
             var response = new HttpResponseBase(HttpStatusCode.BadRequest, descr, "HTTP/1.1");
+            var counter = (int)channel.Data.GetOrAdd(HttpMessage.PipelineIndexKey, x => 1);
+            response.Headers[HttpMessage.PipelineIndexKey] = counter.ToString();
             channel.Send(response);
             channel.Close();
         }


### PR DESCRIPTION
the PipelinedMessageQueue requires that the  HttpMessage.PipelineIndexKey header is set on the response

Sorry no tests because it is really hard to get messages enqueued inside of tests.