### PR TITLE
reset header parser in HttpMessageDecoder#Clear

### DIFF
--- a/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpMessageDecoderTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpMessageDecoderTests.cs
@@ -308,5 +308,30 @@ hello queue a");
             new StreamReader(actual.Body, actual.ContentCharset).ReadToEnd().Should().Be("hello queue a");
         }
 
+        [Fact]
+        public void invalid_requests()
+        {
+            var actual = new List<IHttpRequest>();
+            var buffer1 = new SocketBufferFake();
+            buffer1.Buffer = Encoding.ASCII.GetBytes("GET / invalid_request1\r\n");
+            buffer1.BytesTransferred = buffer1.Buffer.Length;
+
+            var buffer2 = new SocketBufferFake();
+            buffer2.Buffer = Encoding.ASCII.GetBytes("GET / invalid_request2\r\n");
+            buffer2.BytesTransferred = buffer2.Buffer.Length;
+
+            var decoder = new HttpMessageDecoder();
+            decoder.MessageReceived = o => actual.Add((IHttpRequest)o);
+
+            var ex1 = Assert.Throws<BadRequestException>(() => decoder.ProcessReadBytes(buffer1));
+            ex1.Message.Should().Contain("'invalid_request1'");
+
+            decoder.Clear();
+
+            var ex2 = Assert.Throws<BadRequestException>(() => decoder.ProcessReadBytes(buffer2));
+            ex2.Message.Should().Contain("'invalid_request2'");
+
+            actual.Count.Should().Be(0);
+        }  
     }
 }

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpMessageDecoder.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpMessageDecoder.cs
@@ -128,6 +128,7 @@ namespace Griffin.Net.Protocols.Http
         {
             _message = null;
             _isHeaderParsed = false;
+            _headerParser.Reset();
             _frameContentBytesLeft = 0;
         }
 


### PR DESCRIPTION
if exceptions are thrown while parsing headers the headerParser is never reset correctly