### PR TITLE
rename test `header_parser_should_be_reset_when_the_decoder_is_reset`

### DIFF
--- a/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpMessageDecoderTests.cs
+++ b/src/Griffin.Framework/Griffin.Core.Tests/Net/Protocols/Http/HttpMessageDecoderTests.cs
@@ -309,7 +309,7 @@ hello queue a");
         }
 
         [Fact]
-        public void invalid_requests()
+        public void header_parser_should_be_reset_when_the_decoder_is_reset()
         {
             var actual = new List<IHttpRequest>();
             var buffer1 = new SocketBufferFake();


### PR DESCRIPTION
as proposed in https://github.com/jgauffin/Griffin.Framework/pull/29#issuecomment-75031494