### PR TITLE
CompositeSerializer fix and implementation of QueryString parameter collection

### DIFF
--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpRequestBase.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Http/HttpRequestBase.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Net;
+using Griffin.Net.Protocols.Http.Messages;
 using Griffin.Net.Protocols.Http.Serializers;
 using Griffin.Net.Protocols.Serializers;
+using System.IO;
 
 namespace Griffin.Net.Protocols.Http
 {
@@ -24,6 +26,7 @@ namespace Griffin.Net.Protocols.Http
         private string _pathAndQuery;
         private string _httpMethod;
         private Uri _uri;
+        private IParameterCollection _queryString = null;
 
         /// <summary>
         /// 
@@ -72,6 +75,39 @@ namespace Griffin.Net.Protocols.Http
                     throw new ArgumentNullException("value");
                 _uri = value;
                 _pathAndQuery = value.PathAndQuery;
+                _queryString = null; // force regeneration on next QueryString property access
+            }
+        }
+
+        /// <summary>
+        ///     Collection of parameters extracted from the requested URI.
+        /// </summary>
+        public IParameterCollection QueryString
+        {
+            get
+            {
+                if (_queryString == null)
+                {
+                    _queryString = new ParameterCollection();
+                    var query = Uri.Query;
+                    if (query.Length > 1) // question mark is always part of the query string
+                    {
+                        var decoder = new UrlDecoder();
+                        using (var reader = new StringReader(Uri.Query))
+                        {
+                            reader.Read(); // question mark
+                            decoder.Parse(reader, _queryString);
+                        }
+                    }
+                }
+                
+                return _queryString;
+            }
+            internal set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _queryString = value;
             }
         }
 

--- a/src/Griffin.Framework/Griffin.Core/Net/Protocols/Serializers/CompositeSerializer.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/Protocols/Serializers/CompositeSerializer.cs
@@ -70,10 +70,9 @@ namespace Griffin.Net.Protocols.Serializers
             var contentTypeTrimmed = GetContentTypeWithoutCharset(contentType);
 
             if (!_decoders.TryGetValue(contentTypeTrimmed, out decoder))
-                return false;
+                return null;
 
-            decoder.Deserialize(contentType, source);
-            return true;
+            return decoder.Deserialize(contentType, source);
         }
 
         /// <summary>


### PR DESCRIPTION
Hello,

I've noticed that under certain conditions the HTTP request throws exception during parsing and I've found that it was successfully parsed, but then the result was thrown away in CompositeSerializer. I've put in a fix - pass on the result or return null.

I've also added support for QueryString. The additional overhead is minimal (assigns null in the constructor) and the actual collection is generated on demand.
