### PR TITLE
Keep track of used channels and close the connection on stop

### DIFF
--- a/src/Griffin.Framework/Griffin.Core/Net/ChannelTcpListener.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/ChannelTcpListener.cs
@@ -8,6 +8,7 @@ using Griffin.Net.Channels;
 using Griffin.Net.Protocols;
 using Griffin.Net.Protocols.MicroMsg;
 using Griffin.Net.Protocols.Serializers;
+using System.Linq;
 
 namespace Griffin.Net
 {
@@ -144,10 +145,9 @@ namespace Griffin.Net
         {
             _shuttingDown = true;
             _listener.Stop();
-            foreach(var channel in _usedChannels)
-            {
-                channel.Value.CloseAsync();
-            }
+            var tasks = _usedChannels.Values.Select(x => x.CloseAsync()).ToArray();
+            if (tasks.Any())
+                System.Threading.Tasks.Task.WaitAll(tasks);
         }
 
         /// <summary>


### PR DESCRIPTION
TcpListener doesn't keep track of used channels and close them on stop. The result is that any established connection continues to be served even after the listener is stopped. 
One example is using Griffin.WebServer.HttpServer to serve a web page. If the HttpServer is stopped, the connection remains, until the client browser is stopped.