### PR TITLE
Fixed unhandled SemaphoreFullException when messages arrive while ReceiveAsync is still executing

### DIFF
--- a/src/Griffin.Framework/Griffin.Core/Net/ChannelTcpClient.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/ChannelTcpClient.cs
@@ -26,7 +26,7 @@ namespace Griffin.Net
         private readonly IMessageEncoder _encoder;
         private readonly IBufferSlice _readBuffer;
         private readonly ConcurrentQueue<object> _readItems = new ConcurrentQueue<object>();
-        private readonly SemaphoreSlim _readSemaphore = new SemaphoreSlim(0, 1);
+		private readonly AutoResetEvent _readEvent = new AutoResetEvent(false);
         private readonly SemaphoreSlim _sendCompletedSemaphore = new SemaphoreSlim(0, 1);
         private readonly SemaphoreSlim _sendQueueSemaphore = new SemaphoreSlim(1, 1);
         private ITcpChannel _channel;
@@ -260,25 +260,31 @@ namespace Griffin.Net
         /// </exception>
         public async Task<object> ReceiveAsync(TimeSpan timeout, CancellationToken cancellation)
         {
-            await _readSemaphore.WaitAsync(timeout, cancellation);
-            if (cancellation.IsCancellationRequested)
-                return null;
+			return await Task.Run(() =>
+			{
+				var handles = new WaitHandle[] { _readEvent, cancellation.WaitHandle };
 
-            object item;
-            var gotItem = _readItems.TryDequeue(out item);
+				WaitHandle.WaitAny(handles);
 
-            if (!gotItem)
-                throw new ChannelException(
-                    "Was signalled that something have been received, but found nothing in the in queue");
+				if (cancellation.IsCancellationRequested)
+					return null;
 
-            if (item is ChannelException)
-                throw (ChannelException) item;
+				object item;
+				var gotItem = _readItems.TryDequeue(out item);
 
-            // signal so that more items can be read directly
-            if (_readItems.Count > 0)
-                _readSemaphore.Release();
+				if (!gotItem)
+					throw new ChannelException(
+						"Was signalled that something have been received, but found nothing in the in queue");
 
-            return item;
+				if (item is ChannelException)
+					throw (ChannelException)item;
+
+				// signal so that more items can be read directly
+				if (_readItems.Count > 0)
+					_readEvent.Set();
+
+				return item;
+			});
         }
 
         /// <summary>
@@ -329,8 +335,7 @@ namespace Griffin.Net
 
 
             _readItems.Enqueue(message);
-            if (_readSemaphore.CurrentCount == 0)
-                _readSemaphore.Release();
+			_readEvent.Set();
         }
 
         /// <summary>
@@ -372,10 +377,10 @@ namespace Griffin.Net
                 _sendCompletedSemaphore.Release();
             }
 
-            if (_readSemaphore.CurrentCount == 0)
+            if (!_readEvent.WaitOne(0))
             {
                 _readItems.Enqueue(new ChannelException("Socket got disconnected", arg2));
-                _readSemaphore.Release();
+				_readEvent.Set();
             }
         }
 

--- a/src/Griffin.Framework/Griffin.Core/Net/ChannelTcpClient.cs
+++ b/src/Griffin.Framework/Griffin.Core/Net/ChannelTcpClient.cs
@@ -26,7 +26,7 @@ namespace Griffin.Net
         private readonly IMessageEncoder _encoder;
         private readonly IBufferSlice _readBuffer;
         private readonly ConcurrentQueue<object> _readItems = new ConcurrentQueue<object>();
-		private readonly AutoResetEvent _readEvent = new AutoResetEvent(false);
+        private readonly AutoResetEvent _readEvent = new AutoResetEvent(false);
         private readonly SemaphoreSlim _sendCompletedSemaphore = new SemaphoreSlim(0, 1);
         private readonly SemaphoreSlim _sendQueueSemaphore = new SemaphoreSlim(1, 1);
         private ITcpChannel _channel;
@@ -260,31 +260,31 @@ namespace Griffin.Net
         /// </exception>
         public async Task<object> ReceiveAsync(TimeSpan timeout, CancellationToken cancellation)
         {
-			return await Task.Run(() =>
-			{
-				var handles = new WaitHandle[] { _readEvent, cancellation.WaitHandle };
+            return await Task.Run(() =>
+            {
+                var handles = new WaitHandle[] { _readEvent, cancellation.WaitHandle };
 
-				WaitHandle.WaitAny(handles);
+                WaitHandle.WaitAny(handles);
 
-				if (cancellation.IsCancellationRequested)
-					return null;
+                if (cancellation.IsCancellationRequested)
+                    return null;
 
-				object item;
-				var gotItem = _readItems.TryDequeue(out item);
+                object item;
+                var gotItem = _readItems.TryDequeue(out item);
 
-				if (!gotItem)
-					throw new ChannelException(
-						"Was signalled that something have been received, but found nothing in the in queue");
+                if (!gotItem)
+                    throw new ChannelException(
+                        "Was signalled that something have been received, but found nothing in the in queue");
 
-				if (item is ChannelException)
-					throw (ChannelException)item;
+                if (item is ChannelException)
+                    throw (ChannelException)item;
 
-				// signal so that more items can be read directly
-				if (_readItems.Count > 0)
-					_readEvent.Set();
+                // signal so that more items can be read directly
+                if (_readItems.Count > 0)
+                    _readEvent.Set();
 
-				return item;
-			});
+                return item;
+            });
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace Griffin.Net
 
 
             _readItems.Enqueue(message);
-			_readEvent.Set();
+            _readEvent.Set();
         }
 
         /// <summary>
@@ -380,7 +380,7 @@ namespace Griffin.Net
             if (!_readEvent.WaitOne(0))
             {
                 _readItems.Enqueue(new ChannelException("Socket got disconnected", arg2));
-				_readEvent.Set();
+                _readEvent.Set();
             }
         }
 


### PR DESCRIPTION
_readSemaphore has been replaced with _readEvent, because an event can be safely Set multiple times in a row, while semaphore can be unintentionally Release'ed beyond its maximum level. When server sends messages faster than the client reads, and OnChannelMessageReceived is called while ReceiveAsync is still executing, the _readSemaphore is Release'ed twice -- first in on OnChannelMessageReceived, then second time at the end of ReceiveAsync (because readItems.Count > 0) which lead to unhandled SemaphoreFullException in ReceiveAsync

The offending data flow:

1. OnChannelMessageReceived  (readSemaphore.Release())   ----- readSemaphore.Count == 1
2. WaitOne is triggered at the beginning of ReceiveAsync  ----- readSemaphore.Count == 0
3. Another OnChannelMessageReceived (readSemaphore.Release()) --- readSemaphoreCount == 1
4. End of ReceiveAsync (if (_readItems.Count > 0) readSemaphore.Release()) -- readSemaphoreCount == 2 -- SemaphoreFullException